### PR TITLE
Another unicode fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 aws-release-notes-rss
 =====================
 
-Scrape the AWS service release notes and spit out a RSS feed
+Scrape the AWS service release notes and spit out an RSS feed.
 
-Point your newsreader here: https://tedder.me/rss/aws-release-notes.xml
+Point your newsreader here: https://dyn.tedder.me/rss/aws-release-notes.xml
 
 ```
 pip3 install PyRSS2Gen requests boto3

--- a/scrape.py
+++ b/scrape.py
@@ -16,7 +16,6 @@ import boto3
 import requests
 import PyRSS2Gen
 import datetime
-from io import StringIO
 import sys
 from dateutil.parser import parse
 
@@ -49,13 +48,12 @@ rss = PyRSS2Gen.RSS2(
     items = map(item_to_rss, request.json()["items"])
 )
 
-rssfile = StringIO()
-rss.write_xml(rssfile)
+rssdata = rss.to_xml(request.encoding)
 
 
 s3 = boto3.client("s3")
 if "tedder" in map(lambda b: b["Name"], s3.list_buckets()["Buckets"]):
-    s3.put_object(Bucket="dyn.tedder.me", Key="rss/aws-release-notes.xml", Body=rssfile.getvalue(), ContentType="application/rss+xml", ContentEncoding=request.encoding, CacheControl="max-age=21600,public", ACL="public-read")
-    s3.put_object(Bucket="tedder", Key="rss/aws-release-notes.xml", Body=rssfile.getvalue(), ContentType="application/rss+xml", ContentEncoding=request.encoding, CacheControl="max-age=21600,public", ACL="public-read")
+    s3.put_object(Bucket="dyn.tedder.me", Key="rss/aws-release-notes.xml", Body=rssdata, ContentType="application/rss+xml", ContentEncoding=request.encoding, CacheControl="max-age=21600,public", ACL="public-read")
+    s3.put_object(Bucket="tedder", Key="rss/aws-release-notes.xml", Body=rssdata, ContentType="application/rss+xml", ContentEncoding=request.encoding, CacheControl="max-age=21600,public", ACL="public-read")
 else:
-    print(rssfile.getvalue())
+    print(rssdata)

--- a/scrape.py
+++ b/scrape.py
@@ -12,25 +12,28 @@
 #
 # THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+import os
+import sys
 import boto3
 import requests
 import PyRSS2Gen
 import datetime
-import sys
-from dateutil.parser import parse
+import dateutil
 
 def item_to_rss(item):
     link = "https://aws.amazon.com/"+item["id"].replace("#","/")+"/"
-    desc = item['additionalFields'].get('description', '')
-    if not desc:
-      item['additionalFields'].get('content', '')
+    desc = ""
+    if "description" in item["additionalFields"]:
+        desc = item["additionalFields"]["description"]
+    elif "content" in item["additionalFields"]:
+        desc = item["additionalFields"]["content"]
     return PyRSS2Gen.RSSItem(
         author = item["author"],
         title = item["name"],
         link = link,
         guid = link,
         description = desc,
-        pubDate = parse(item["dateUpdated"])
+        pubDate = dateutil.parser.parse(item["dateUpdated"])
     )
 
 request = requests.get("https://aws.amazon.com/api/dirs/releasenotes/items?order_by=DateCreated&sort_ascending=false&limit=25&locale=en_US")

--- a/scrape.py
+++ b/scrape.py
@@ -51,9 +51,12 @@ rss = PyRSS2Gen.RSS2(
 rssdata = rss.to_xml(request.encoding)
 
 
-s3 = boto3.client("s3")
-if "tedder" in map(lambda b: b["Name"], s3.list_buckets()["Buckets"]):
-    s3.put_object(Bucket="dyn.tedder.me", Key="rss/aws-release-notes.xml", Body=rssdata, ContentType="application/rss+xml", ContentEncoding=request.encoding, CacheControl="max-age=21600,public", ACL="public-read")
-    s3.put_object(Bucket="tedder", Key="rss/aws-release-notes.xml", Body=rssdata, ContentType="application/rss+xml", ContentEncoding=request.encoding, CacheControl="max-age=21600,public", ACL="public-read")
+if "S3_BUCKET_NAME" in os.environ:
+    s3 = boto3.client("s3")
+    s3.put_object(Bucket=os.environ["S3_BUCKET_NAME"], Key="rss/aws-release-notes.xml", Body=rssdata, ContentType="application/rss+xml", ContentEncoding=request.encoding, CacheControl="max-age=21600,public", ACL="public-read")
+
+    # also upload to legacy bucket:
+    if os.environ["S3_BUCKET_NAME"] == "dyn.tedder.me":
+        s3.put_object(Bucket="tedder", Key="rss/aws-release-notes.xml", Body=rssdata, ContentType="application/rss+xml", ContentEncoding=request.encoding, CacheControl="max-age=21600,public", ACL="public-read")
 else:
     print(rssdata)


### PR DESCRIPTION
Hi again!

I guess my last fix in #4 was not sufficient. I think at that time, the news item with the unicode character was no longer in the feed, so I wasn't able to test it after the fix. However, at this moment, it's the second item.

> AWS Cost Explorer’s Reserved Instance Reports now Support Amazon Elasticsearch Reservations

Appears in my RSS reader as:

> AWS Cost Explorerâ€™s Reserved Instance Reports now Support Amazon Elasticsearch Reservations

I noticed that the xml header is `<?xml version="1.0" encoding="iso-8859-1"?>` so maybe that is why.. The rss package supports an encoding argument, so this PR changes it to `<?xml version="1.0" encoding="UTF-8"?>`.

I also tried using `BytesIO`, which made the unicode characters appear as HTML entities. If this attempt doesn't solve it, then we can try that.

I also introduced `S3_BUCKET_NAME` (as we briefly touched on in #2). So you'd have to set it to `dyn.tedder.me`. When you deprecate the old location, I would suggest replacing the file with a new RSS feed that only has one item that says that the feed has moved. So many times have I encountered feeds that just disappear, which defeats the purpose of an RSS feed a little bit.

Anyway, let me know if you want me to change anything! Thanks!