### PR TITLE
Remove ContentEncoding

### DIFF
--- a/scrape.py
+++ b/scrape.py
@@ -74,7 +74,6 @@ if os.environ.get('S3_BUCKET_NAME'):
     Key="rss/aws-release-notes.xml",
     Body=rssdata,
     ContentType="application/rss+xml",
-    ContentEncoding=request.encoding,
     CacheControl="max-age=21600,public",
     ACL="public-read"
   )


### PR DESCRIPTION
Remove ContentEncoding as this is not how it is supposed to be used and it breaks some feed readers.

I was really wrong in #4. This header is not supposed to be used for text encoding. It is only used to indicate compression of the content, as described here: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Encoding.

I just realized that my RSS reader hasn't been updating this feed for about a year because of this. It is probably causing problems for others. Please accept my apologies. :)